### PR TITLE
Fix `source-map-explorer`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -62,7 +62,7 @@ async function generateSourceMapExplorer(
   const output = `${outputDirectory}/${filename}.html`;
 
   await execa(
-    `npx source-map-explorer ${sourceDirectory}/${filename}.jsbundle --html ${output}`,
+    `npx source-map-explorer ${sourceDirectory}/${filename}.jsbundle --no-border-checks --html ${output}`,
     { shell: true }
   );
 


### PR DESCRIPTION
On the latest few versions of React Native (checked on 0.75 and above), the `source-map-explorer dependency` is crashing by incorrect mappings produced by Metro bundler:

```sh
Error: Command failed with exit code 1: npx source-map-explorer /var/folders/87/h1fwbh2s6j5g0k7rxyzmq1bc0000gn/T/tmp-95768-gZFWLTpjnXWN/BundleSize/original.jsbundle --html /var/folders/87/h1fwbh2s6j5g0k7rxyzmq1bc0000gn/T/tmp-95768-nKWqOzrWcgTF/original.html
  Your source map refers to generated column 2141 on line 2, but the source only contains 2140 column(s) on that line.
  Check that you are using the correct source map.
/var/folders/87/h1fwbh2s6j5g0k7rxyzmq1bc0000gn/T/tmp-95768-gZFWLTpjnXWN/BundleSize/original.jsbundle
```