### PR TITLE
Add `engines.node: ">=20"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/charpeni/react-native-bundle-scale.git"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "main": "src/index.js",
   "bin": "src/index.js",
   "scripts": {


### PR DESCRIPTION
React Native (the CLI at least) doesn't work below Node 20.